### PR TITLE
笑顔検出アルゴリズムとサファリエラーの修正

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,34 +1,85 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { db, type Snap } from "@/lib/db";
 import { useRouter } from "next/navigation";
 
 export default function HistoryPage() {
   const router = useRouter();
   const [items, setItems] = useState<Array<{ snap: Snap; url: string }>>([]);
+  // 生成した blob: URL を追跡して確実に解放（Safari 安定化）
+  const createdUrlsRef = useRef<string[]>([]);
+
+  const ensureJpegBlob = (b: Blob): Blob => {
+    if (b.type && b.type.startsWith("image/")) return b;
+    return new Blob([b], { type: "image/jpeg" });
+  };
+
+  const blobToDataUrl = (blob: Blob): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => resolve(String(fr.result));
+      fr.onerror = () => reject(fr.error);
+      fr.readAsDataURL(blob);
+    });
 
   useEffect(() => {
     let mounted = true;
     (async () => {
       const snaps = await db.snaps.orderBy("takenAt").reverse().toArray();
       if (!mounted) return;
-      const withUrl = snaps.map((s) => ({
-        snap: s,
-        url: URL.createObjectURL(s.blob),
-      }));
+      const withUrl = snaps.map((s) => {
+        const typed = ensureJpegBlob(s.blob);
+        const url = URL.createObjectURL(typed);
+        createdUrlsRef.current.push(url);
+        return { snap: s, url };
+      });
       setItems(withUrl);
     })();
     return () => {
       mounted = false;
-      // 生成した URL を解放
-      items.forEach((i) => URL.revokeObjectURL(i.url));
+      // 生成した blob: URL を確実に解放
+      for (const u of createdUrlsRef.current) {
+        try {
+          URL.revokeObjectURL(u);
+        } catch {}
+      }
+      createdUrlsRef.current = [];
     };
   }, []);
 
   const remove = async (id: string) => {
     await db.snaps.delete(id);
-    setItems((prev) => prev.filter((i) => i.snap.id !== id));
+    setItems((prev) => {
+      const target = prev.find((i) => i.snap.id === id);
+      if (target && target.url.startsWith("blob:")) {
+        try {
+          URL.revokeObjectURL(target.url);
+        } catch {}
+      }
+      return prev.filter((i) => i.snap.id !== id);
+    });
+  };
+
+  // Safari で blob: URL の表示に失敗した場合のフォールバック
+  const handleImageError = async (id: string) => {
+    try {
+      const snap = await db.snaps.get(id);
+      if (!snap) return;
+      const typed = ensureJpegBlob(snap.blob);
+      const dataUrl = await blobToDataUrl(typed);
+      setItems((prev) =>
+        prev.map((i) => {
+          if (i.snap.id !== id) return i;
+          if (i.url.startsWith("blob:")) {
+            try {
+              URL.revokeObjectURL(i.url);
+            } catch {}
+          }
+          return { ...i, url: dataUrl };
+        })
+      );
+    } catch {}
   };
 
   return (
@@ -51,6 +102,7 @@ export default function HistoryPage() {
               src={url}
               alt="記録写真"
               className="w-full aspect-video object-cover"
+              onError={() => handleImageError(snap.id)}
             />
             <div className="p-2 text-xs opacity-70">
               {new Date(snap.takenAt).toLocaleString()}（

--- a/src/app/record/page.tsx
+++ b/src/app/record/page.tsx
@@ -146,18 +146,57 @@ export default function RecordPage() {
       const now = performance.now();
       const res = lm.detectForVideo(v, now);
       const bs = res?.faceBlendshapes?.[0]?.categories;
-      const L =
-        bs?.find((c) => c.categoryName === "mouthSmileLeft")?.score ?? 0;
-      const R =
-        bs?.find((c) => c.categoryName === "mouthSmileRight")?.score ?? 0;
+      // ---- 新スコア計算 ----
+      // 口: 左右口角と下唇の中心から角度を計算し s_mouth = α - β * θ
+      const face = res?.faceLandmarks?.[0];
+      const MOUTH_LEFT_IDX = 61; // 左口角
+      const MOUTH_RIGHT_IDX = 291; // 右口角
+      const MOUTH_BOTTOM_CENTER_IDX = 14; // 下唇の内側・下中心（近似）
+
+      let s_mouth = 0;
+      if (face) {
+        const PL = face[MOUTH_LEFT_IDX];
+        const PR = face[MOUTH_RIGHT_IDX];
+        const PB = face[MOUTH_BOTTOM_CENTER_IDX];
+        if (PL && PR && PB) {
+          const vLx = PL.x - PB.x;
+          const vLy = PL.y - PB.y;
+          const vRx = PR.x - PB.x;
+          const vRy = PR.y - PB.y;
+          const dot = vLx * vRx + vLy * vRy;
+          const magL = Math.hypot(vLx, vLy);
+          const magR = Math.hypot(vRx, vRy);
+          if (magL > 1e-6 && magR > 1e-6) {
+            let cosTheta = dot / (magL * magR);
+            // 数値誤差ガード
+            cosTheta = Math.max(-1, Math.min(1, cosTheta));
+            const thetaDeg = (Math.acos(cosTheta) * 180) / Math.PI; // 度
+            const ALPHA = 1.8;
+            const BETA = 0.01;
+            s_mouth = ALPHA - BETA * thetaDeg;
+          }
+        }
+      }
+
+      // 目: ブレンドシェイプの eyeBlink を用いて開眼確率を近似
+      const blinkL =
+        bs?.find((c) => c.categoryName === "eyeBlinkLeft")?.score ?? 0;
+      const blinkR =
+        bs?.find((c) => c.categoryName === "eyeBlinkRight")?.score ?? 0;
+      // 開眼確率を 1 - blink として近似し、[0,1]へクリップ
+      const P_open_L = Math.max(0, Math.min(1, 1 - blinkL));
+      const P_open_R = Math.max(0, Math.min(1, 1 - blinkR));
+      const s_eye = 1 - P_open_L * P_open_R; // 指定式
+
+      // 最終スコア: S = clamp(s_mouth + s_eye, 0, 1)
+      const S = Math.max(0, Math.min(1, s_mouth + s_eye));
 
       // 簡易スムージング（1フレームぶれ対策）
-      const score = Math.max(0, Math.min(1, (L + R) / 2));
-      setSmileScore((prev) => prev * 0.6 + score * 0.4);
+      setSmileScore((prev) => prev * 0.6 + S * 0.4);
 
       // 段階（tier）更新＆メッセージ
       const nextTier: 0 | 1 | 2 | 3 =
-        score >= TIER3 ? 3 : score >= TIER2 ? 2 : score >= TIER1 ? 1 : 0;
+        S >= TIER3 ? 3 : S >= TIER2 ? 2 : S >= TIER1 ? 1 : 0;
 
       // setInterval のクロージャで state が古くなるのを避けるため、
       // カウントダウン中かどうかは armTimerRef の有無で判定する
@@ -393,6 +432,15 @@ export default function RecordPage() {
               className={`rounded-full px-3 py-1 text-xs font-semibold bg-white/90 backdrop-blur shadow animate-pop`}
             >
               {badgeText}
+            </div>
+          </div>
+        )}
+
+        {/* 笑顔スコアのリアルタイム表示 */}
+        {!showImage && (
+          <div className="pointer-events-none absolute top-0 right-0 p-3">
+            <div className="rounded-full px-3 py-1 text-xs font-semibold bg-white/90 backdrop-blur shadow">
+              S: {smileScore.toFixed(2)}
             </div>
           </div>
         )}

--- a/src/lib/useFaceSmile.ts
+++ b/src/lib/useFaceSmile.ts
@@ -1,49 +1,99 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FaceLandmarker, FilesetResolver } from "@mediapipe/tasks-vision";
+
+type Point = { x: number; y: number };
+type MouthKeypoints = {
+  leftCorner: Point; // 左口角（正規化座標0..1）
+  rightCorner: Point; // 右口角（正規化座標0..1）
+  lowerLipUpperCenter: Point; // 下唇の上辺中心（正規化座標0..1）
+  pixels: {
+    leftCorner: Point;
+    rightCorner: Point;
+    lowerLipUpperCenter: Point;
+  };
+};
+
+// MediaPipe FaceMesh の一般的なランドマーク番号
+// - 左口角: 61
+// - 右口角: 291
+// - 下唇の上辺中心（inner 下唇の上端）: 14
+const LM_MOUTH_LEFT = 61;
+const LM_MOUTH_RIGHT = 291;
+const LM_LOWER_LIP_UPPER_CENTER = 14;
 
 export function useFaceSmile() {
   const lmRef = useRef<FaceLandmarker | null>(null);
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      // ❶ WASM一式をCDNから読み込む（バージョンはプロジェクトに合わせて固定してOK）
-      const wasmBase =
-        "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.12/wasm";
-      const fileset = await FilesetResolver.forVisionTasks(wasmBase);
+      try {
+        const wasmBase =
+          "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.12/wasm";
+        const fileset = await FilesetResolver.forVisionTasks(wasmBase);
+        const modelUrl =
+          "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task";
 
-      // ❷ 顔モデル（.task）もCDN/公式ストレージから
-      const modelUrl =
-        "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task";
-
-      const lm = await FaceLandmarker.createFromOptions(fileset, {
-        baseOptions: { modelAssetPath: modelUrl },
-        runningMode: "IMAGE",
-        outputFaceBlendshapes: true,
-        numFaces: 1,
-      });
-      if (!cancelled) lmRef.current = lm;
+        const lm = await FaceLandmarker.createFromOptions(fileset, {
+          baseOptions: { modelAssetPath: modelUrl },
+          runningMode: "VIDEO",
+          outputFaceBlendshapes: true,
+          numFaces: 1,
+        });
+        if (!cancelled) {
+          lmRef.current = lm;
+          setReady(true);
+        }
+      } catch (e) {
+        console.error("FaceLandmarker init failed", e);
+      }
     })();
     return () => {
       cancelled = true;
       lmRef.current?.close();
       lmRef.current = null;
+      setReady(false);
     };
   }, []);
 
-  async function scoreSmileFromCanvas(
-    canvas: HTMLCanvasElement
-  ): Promise<number | null> {
+  // 将来 ML Kit に差し替えるためのインターフェイス。
+  // いまは Web なので MediaPipe で同等の3点を返す。
+  function detectMouthKeypointsForVideo(
+    video: HTMLVideoElement
+  ): MouthKeypoints | null {
     const lm = lmRef.current;
-    if (!lm) return null;
-    const res = lm.detect(canvas);
-    const bs = res?.faceBlendshapes?.[0]?.categories;
-    if (!bs) return 0;
-    const L = bs.find((c) => c.categoryName === "mouthSmileLeft")?.score ?? 0;
-    const R = bs.find((c) => c.categoryName === "mouthSmileRight")?.score ?? 0;
-    return (L + R) / 2;
+    if (!lm || video.readyState < 2 || video.paused) return null;
+    const ts = performance.now();
+    const res = lm.detectForVideo(video, ts);
+    const face = res?.faceLandmarks?.[0];
+    if (!face) return null;
+
+    const W = video.videoWidth || 1;
+    const H = video.videoHeight || 1;
+
+    const pLeft = face[LM_MOUTH_LEFT];
+    const pRight = face[LM_MOUTH_RIGHT];
+    const pCenter = face[LM_LOWER_LIP_UPPER_CENTER];
+    if (!pLeft || !pRight || !pCenter) return null;
+
+    const toPix = (p: any): Point => ({ x: p.x * W, y: p.y * H });
+    const leftCorner = { x: pLeft.x, y: pLeft.y };
+    const rightCorner = { x: pRight.x, y: pRight.y };
+    const lowerLipUpperCenter = { x: pCenter.x, y: pCenter.y };
+
+    return {
+      leftCorner,
+      rightCorner,
+      lowerLipUpperCenter,
+      pixels: {
+        leftCorner: toPix(pLeft),
+        rightCorner: toPix(pRight),
+        lowerLipUpperCenter: toPix(pCenter),
+      },
+    };
   }
 
-  return { scoreSmileFromCanvas };
+  return { ready, detectMouthKeypointsForVideo };
 }


### PR DESCRIPTION
#MediaPipeのランドマークとブレンドシェイプを用いて、指定の新しい笑顔スコア S をリアルタイム計算するように変更しています。
実装ポイント
* 定義
    * 口角: 61（左）、291（右）
    * 口の底の中心: 14（下唇内側の中心を近似として使用）
    * 定数: α=1.8、β=0.01
* s_mouth
    * PB（口の底中心）→左右口角へのベクトルで角度 θ を計算
    * θ[deg] = acos((vL·vR)/(|vL||vR|))×180/π
    * s_mouth = 1.8 - 0.01 × θ
* s_eye
    * MediaPipeのブレンドシェイプから eyeBlinkLeft/eyeBlinkRight を取得
    * 開眼確率近似: P_open = 1 - blink（[0,1]にクリップ）
    * s_eye = 1 - P_open_L × P_open_R（ご指定の式）
* 最終スコア
    * S = clamp(s_mouth + s_eye, 0, 1)
    * 既存のスムージングを継承: smileScore = prev*0.6 + S*0.4
    * 既存の段階化（TIER1/2/3）は S を元に判定
補足
* 下唇の「底の中心」については MediaPipeのインデックス 14 を下唇内側中心の近似として採用しています。厳密に外側の底中心が必要であれば、該当インデックスの指定に差し替えます（ご希望があれば指示ください）。
* s_eye の式はご指定通り実装しています（両目が開いているほど P_open が高く、式の結果は小さくなります）。もし「開いているほど s_eye を大きくしたい」意図でしたら、式の見直し案も提示可能です。
* パフォーマンスは従来と同等で、1回の推論でランドマークとブレンドシェイプを併用し、簡易スムージングを維持しています。


#Safariで履歴画像が「はてなボックス」になる問題に対して、履歴画面の画像生成と解放、そしてフェイルオーバーを強化しています。

変更点

JPEGタイプの保証: IndexedDBから取り出したBlobのMIMEが欠落している場合にimage/jpegを付与してからcreateObjectURLを生成。
URLの適切な解放: 生成したblob:URLをすべて追跡し、アンマウント時・削除時・フォールバック時に確実にrevokeObjectURL。
Safari向けフォールバック: imgのonErrorで表示に失敗した場合、Blobをdata:URL（base64）に変換して差し替え。これによりSafariのblob:表示不具合を回避。
該当ファイル

src/app/history/page.tsx: URL生成・解放管理、onErrorフォールバックを追加。
補足

Data URLはメモリを多く使うため、通常はblob:URLを使用し、失敗時のみ自動で切替えます。
すでに保存済みの古いレコードでも、フォールバックが働いて表示できるはずです。
長期利用で履歴を大量表示する場合、引き続きURL解放が重要です（今回の修正で解放漏れも減ります）。
もしSafariのバージョンやiOSの特定端末で再現する場合があれば、確認し最適化を続けます。配置位置や表示品質の調整も可能です。