### PR TITLE
フィードバックコメントのバリエーション追加とデザイン変更

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --accent-start: #7c3aed; /* violet-600 */
+  --accent-end: #06b6d4;   /* cyan-500 */
 }
 
 @theme inline {
@@ -16,11 +18,50 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --accent-start: #8b5cf6; /* lighter violet */
+    --accent-end: #22d3ee;   /* lighter cyan */
   }
 }
 
 body {
-  background: var(--background);
+  /* Soft gradient background with subtle radial accents */
+  background:
+    radial-gradient(1200px 600px at 0% -10%, color-mix(in oklab, var(--accent-start) 10%, transparent) 0%, transparent 60%),
+    radial-gradient(1000px 500px at 110% 10%, color-mix(in oklab, var(--accent-end) 12%, transparent) 0%, transparent 65%),
+    linear-gradient(180deg, color-mix(in oklab, var(--background) 98%, transparent) 0%, var(--background) 60%);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Glassy surface helper */
+.glass {
+  background: color-mix(in oklab, var(--background) 86%, transparent);
+  backdrop-filter: blur(10px) saturate(1.05);
+  -webkit-backdrop-filter: blur(10px) saturate(1.05);
+}
+
+/* Gradient border wrapper: place content as a child with .inner */
+.gradient-border {
+  position: relative;
+  padding: 2px;
+  border-radius: 1.25rem; /* ~ rounded-2xl */
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+}
+.gradient-border .inner {
+  border-radius: inherit;
+  background: color-mix(in oklab, var(--background) 92%, transparent);
+}
+
+/* Primary gradient button */
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  color: white;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+}
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-primary:active { filter: brightness(0.95); }
+
+.btn-outline {
+  border: 1px solid color-mix(in oklab, var(--foreground) 15%, transparent);
+  background: color-mix(in oklab, var(--background) 92%, transparent);
 }

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -86,19 +86,19 @@ export default function HistoryPage() {
   return (
     <main className="mx-auto max-w-xl p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold">記録履歴</h1>
+        <h1 className="text-2xl font-semibold">記録履歴</h1>
         <button
           onClick={() => router.push("/")}
-          className="inline-flex items-center gap-1 rounded-xl border px-3 py-2"
+          className="inline-flex items-center gap-1 rounded-2xl btn-outline px-4 py-2"
           aria-label="はじめのページへ戻る"
         >
           ← はじめのページへ
         </button>
       </div>
 
-      <ul className="grid grid-cols-2 gap-3">
+      <ul className="grid grid-cols-2 gap-4">
         {items.map(({ snap, url }) => (
-          <li key={snap.id} className="rounded-xl overflow-hidden border">
+          <li key={snap.id} className="rounded-2xl overflow-hidden glass shadow border border-white/20">
             <div className="relative w-full aspect-video">
               <Image
                 src={url}
@@ -110,10 +110,31 @@ export default function HistoryPage() {
                 onError={() => handleImageError(snap.id)}
               />
             </div>
-            <div className="p-2 text-xs opacity-70">
-              {new Date(snap.takenAt).toLocaleString()}（
-              {snap.eye === "both" ? "両" : snap.eye === "left" ? "左" : "右"}）
+            <div className="p-2 text-xs opacity-80">
+              {new Date(snap.takenAt).toLocaleString()}
             </div>
+            {/* スコア表示（控えめな薄青バッジ） */}
+            <div className="px-2 pb-1 flex items-center gap-2">
+              {(() => {
+                const s = Math.max(0, Math.min(1, snap.smileScore ?? 0));
+                const emoji = s >= 0.8 ? "✨" : s >= 0.6 ? "😁" : s >= 0.4 ? "😊" : "🙂";
+                return (
+                  <span
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-sky-100 text-sky-800 dark:bg-sky-900/60 dark:text-sky-100"
+                  >
+                    {emoji} 笑顔スコア {s.toFixed(2)}
+                  </span>
+                );
+              })()}
+            </div>
+            {/* フィードバックコメント（少し目立つ薄青カード） */}
+            {snap.note && (
+              <div className="px-2 pb-2">
+                <div className="rounded-xl px-3 py-2 text-sm shadow border border-sky-200/80 bg-sky-50 text-sky-900 dark:bg-sky-900/30 dark:text-sky-100 dark:border-sky-400/30">
+                  {snap.note}
+                </div>
+              </div>
+            )}
             <button
               onClick={() => remove(snap.id)}
               className="m-2 text-xs underline"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,18 +6,18 @@ import { useRouter } from "next/navigation";
 export default function Home() {
   const router = useRouter();
   return (
-    <main className="min-h-dvh flex flex-col items-center justify-center gap-6 p-6">
-      <h1 className="text-2xl font-semibold">点眼記録アプリ</h1>
-      <div className="flex flex-col gap-3 w-full max-w-xs">
+    <main className="min-h-dvh flex flex-col items-center justify-center gap-8 p-6">
+      <h1 className="text-3xl md:text-4xl font-semibold">点眼記録アプリ</h1>
+      <div className="flex flex-col gap-4 w-full max-w-xs">
         <button
           onClick={() => router.push("/record")}
-          className="px-4 py-3 rounded-xl bg-black text-white"
+          className="px-5 py-3 rounded-2xl btn-primary"
         >
           点眼記録をつける
         </button>
         <button
           onClick={() => router.push("/history")}
-          className="px-4 py-3 rounded-xl border"
+          className="px-5 py-3 rounded-2xl btn-outline"
         >
           記録を閲覧
         </button>

--- a/src/app/record/page.tsx
+++ b/src/app/record/page.tsx
@@ -65,6 +65,54 @@ export default function RecordPage() {
   const prevMinOpenRef = useRef<number>(1);
   const blinkSuppressUntilRef = useRef<number>(0);
   const selEmaRef = useRef<number>(0);
+  // 撮影後のメッセージ中間部分（バリエーション）
+  const midPhrases: string[] = [
+    "素敵な笑顔ですね！",
+    "ナイススマイル！",
+    "いい表情です！",
+    "スマイル全開です！",
+    "晴れやかな表情ですね！",
+    "すごく良い表情です！",
+    "とても映えてます！",
+    "その笑顔，最高です！",
+    "とっても爽やかです！",
+    "自然で素敵な笑顔です！",
+    "パーフェクトスマイルです！",
+    "とびきりの笑顔ですね！",
+    "今日一番の笑顔ですね！",
+    "元気をもらえる笑顔ですね！",
+    "とても魅力的な笑顔です！",
+    "満点の笑顔！",
+    "ばっちりの笑顔！",
+    "とてもチャーミングです！",
+    "すごく素敵！",
+    "見惚れてしまう笑顔です！",
+    "最高のワンショットです！",
+    "元気いっぱいですね！",
+    "とてもいい表情です！",
+    "気持ちの良い笑顔ですね！",
+    "とても輝いています！",
+    "弾ける笑顔が素敵です！",
+    "爽やかなスマイルですね！",
+  ];
+  const MID_PHRASE_INDEX_KEY = "midPhraseIndex_v1";
+  const chooseMiddle = () => {
+    try {
+      const raw =
+        typeof window !== "undefined"
+          ? window.localStorage.getItem(MID_PHRASE_INDEX_KEY)
+          : null;
+      let idx = raw ? parseInt(raw, 10) : 0;
+      if (!Number.isFinite(idx) || idx < 0 || idx >= midPhrases.length) idx = 0;
+      const phrase = midPhrases[idx] ?? midPhrases[0];
+      const next = (idx + 1) % midPhrases.length;
+      if (typeof window !== "undefined")
+        window.localStorage.setItem(MID_PHRASE_INDEX_KEY, String(next));
+      return phrase;
+    } catch {
+      return midPhrases[0];
+    }
+  };
   // 😊 パーティクル（視覚フィードバック）
   type EmojiParticle = {
     id: number;
@@ -347,7 +395,10 @@ export default function RecordPage() {
       for (let i = 0; i < count; i++) {
         const id = ++particleIdRef.current;
         // 画面の周囲に散らす：中央帯(30-70%)を避けて左右寄りを優先
-        const x = (Math.random() < 0.5 ? 5 + Math.random() * 25 : 70 + Math.random() * 25); // 5–30% or 70–95%
+        const x =
+          Math.random() < 0.5
+            ? 5 + Math.random() * 25
+            : 70 + Math.random() * 25; // 5–30% or 70–95%
         const y = 10 + Math.random() * 80; // 10–90%
         const size = 18 + Math.random() * 10;
         const duration = 800 + Math.random() * 700;
@@ -470,17 +521,21 @@ export default function RecordPage() {
     const id = uuid();
     lastSnapIdRef.current = id;
 
+    const finalScore =
+      bestScoreRef.current === -Infinity ? smileScore : bestScoreRef.current;
+    const middle = chooseMiddle();
+
     await db.snaps.put({
       id,
       takenAt: nowIso,
       eye,
       blob: blob!,
-      smileScore:
-        bestScoreRef.current === -Infinity ? smileScore : bestScoreRef.current,
+      smileScore: finalScore,
+      note: middle, // 中間部分を保存
     });
 
     setIsSaving(false);
-    setMsg("記録しました。素敵な笑顔ですね！今日も目薬頑張ってて偉い！👏");
+    setMsg(`記録しました。${middle} 今日も点眼頑張ってて偉い！👏`);
     setTimeout(() => setShutter(false), 200);
   };
 
@@ -557,89 +612,95 @@ export default function RecordPage() {
         </div>
       )}
 
-      {/* カメラと画像を同じ枠内で切り替え */}
-      <div className="relative w-full max-w-sm aspect-video overflow-hidden rounded-2xl shadow">
-        {/* ライブ映像 */}
-        <video
-          ref={videoRef}
-          className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${
-            showImage ? "opacity-0" : "opacity-100"
-          }`}
-          playsInline
-          muted
-          autoPlay
-        />
-
-        {/* 撮影画像 */}
-        {snapUrl && (
-          <Image
-            src={snapUrl}
-            alt="撮影結果"
-            fill
-            sizes="(max-width: 640px) 100vw, 640px"
-            unoptimized
-            className={`object-cover transition-opacity duration-200 ${
-              showImage ? "opacity-100" : "opacity-0"
+      {/* カメラと画像を同じ枠内で切り替え（リッチなフレーム） */}
+      <div className="gradient-border w-full max-w-sm">
+        <div className="inner relative aspect-video overflow-hidden rounded-2xl shadow">
+          {/* ライブ映像 */}
+          <video
+            ref={videoRef}
+            className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${
+              showImage ? "opacity-0" : "opacity-100"
             }`}
+            playsInline
+            muted
+            autoPlay
           />
-        )}
 
-        {/* 笑顔フィードバック（軽いバッジ） */}
-        {!showImage && badgeText && (
-          <div className="pointer-events-none absolute inset-0 grid place-items-start p-3">
-            <div
-              className={`rounded-full px-3 py-1 text-sm md:text-base font-semibold bg-white/90 dark:bg-black/60 text-black dark:text-white backdrop-blur shadow animate-pop`}
-            >
-              {badgeText}
-            </div>
-          </div>
-        )}
+          {/* 撮影画像 */}
+          {snapUrl && (
+            <Image
+              src={snapUrl}
+              alt="撮影結果"
+              fill
+              sizes="(max-width: 640px) 100vw, 640px"
+              unoptimized
+              className={`object-cover transition-opacity duration-200 ${
+                showImage ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          )}
 
-        {/* 笑顔スコアのリアルタイム表示 */}
-        {!showImage && (
-          <div className="pointer-events-none absolute top-0 right-0 p-3">
-            <div className="rounded-full px-3 py-1 text-sm md:text-base font-semibold bg-white/90 dark:bg-black/60 text-black dark:text-white backdrop-blur shadow">
-              S: {smileScore.toFixed(2)}
-            </div>
-          </div>
-        )}
-
-        {/* 😊 エフェクト（スコア連動） */}
-        {!showImage && particles.length > 0 && (
-          <div className="pointer-events-none absolute inset-0">
-            {particles.map((p) => (
-              <span
-                key={p.id}
-                className="emoji-pop absolute select-none"
-                style={
-                  {
-                    left: `${p.x}%`,
-                    top: `${p.y}%`,
-                    fontSize: `${p.size}px`,
-                    animationDuration: `${p.duration}ms`,
-                    "--dx-start": `${p.dxStart}px`,
-                    "--dx-end": `${p.dxEnd}px`,
-                  } as React.CSSProperties & Record<string, string>
-                }
+          {/* 笑顔フィードバック（軽いバッジ） */}
+          {!showImage && badgeText && (
+            <div className="pointer-events-none absolute inset-0 grid place-items-start p-3">
+              <div
+                className={`rounded-full px-3 py-1 text-sm md:text-base font-semibold bg-white/90 dark:bg-black/60 text-black dark:text-white backdrop-blur shadow animate-pop`}
               >
-                {p.emoji}
-              </span>
-            ))}
-          </div>
-        )}
+                {badgeText}
+              </div>
+            </div>
+          )}
 
-        {/* シャッター幕 */}
-        <div className="pointer-events-none absolute inset-0">
-          <div
-            className={`absolute inset-0 bg-white transition-opacity duration-150 ${
-              shutter ? "opacity-100" : "opacity-0"
-            }`}
-          />
+          {/* 笑顔スコアのリアルタイム表示 */}
+          {!showImage && (
+            <div className="pointer-events-none absolute top-0 right-0 p-3">
+              <div className="rounded-full px-3 py-1 text-sm md:text-base font-semibold bg-white/90 dark:bg-black/60 text-black dark:text-white backdrop-blur shadow">
+                笑顔スコア: {smileScore.toFixed(2)}
+              </div>
+            </div>
+          )}
+
+          {/* 😊 エフェクト（スコア連動） */}
+          {!showImage && particles.length > 0 && (
+            <div className="pointer-events-none absolute inset-0">
+              {particles.map((p) => (
+                <span
+                  key={p.id}
+                  className="emoji-pop absolute select-none"
+                  style={
+                    {
+                      left: `${p.x}%`,
+                      top: `${p.y}%`,
+                      fontSize: `${p.size}px`,
+                      animationDuration: `${p.duration}ms`,
+                      "--dx-start": `${p.dxStart}px`,
+                      "--dx-end": `${p.dxEnd}px`,
+                    } as React.CSSProperties & Record<string, string>
+                  }
+                >
+                  {p.emoji}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* シャッター幕 */}
+          <div className="pointer-events-none absolute inset-0">
+            <div
+              className={`absolute inset-0 bg-white transition-opacity duration-150 ${
+                shutter ? "opacity-100" : "opacity-0"
+              }`}
+            />
+          </div>
         </div>
       </div>
 
       {/* メッセージ（読み上げ対応） */}
-      <p className="text-base md:text-lg text-gray-800 dark:text-gray-200" aria-live="polite" role="status">
+      <p
+        className="text-base md:text-lg text-gray-800 dark:text-gray-200"
+        aria-live="polite"
+        role="status"
+      >
         {msg}
       </p>
 


### PR DESCRIPTION
撮影後の「記録しました。<中間部分> 今日も点眼頑張ってて偉い！👏」の“中間部分”は、配列を先頭から順に使い、最後まで使ったら先頭に戻るサイクル方式です。

実装

連番管理: localStorage に midPhraseIndex_v1 を保持。
取得→配列から該当フレーズを選択→インクリメントして保存（配列長でmod）。
localStorage が使えない場合は先頭要素にフォールバック。
対象: src/app/record/page.tsx:98
chooseMiddle() をランダムからサイクル方式に置き換え。
これで日をまたいでも、基本的に同じフレーズに偏らず、順番にローテーションされます。